### PR TITLE
QueryParams support, better error reporting, pass naked types

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -31,6 +31,7 @@ default-extensions:
   OverloadedStrings
   PolyKinds
   ScopedTypeVariables
+  TypeApplications
   TypeFamilies
   TypeOperators
   UndecidableInstances

--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,7 @@ default-extensions:
   ScopedTypeVariables
   TypeFamilies
   TypeOperators
+  UndecidableInstances
 
 ghc-options:         
   -Wall 

--- a/src/Servant/Client/Generic.hs
+++ b/src/Servant/Client/Generic.hs
@@ -80,6 +80,7 @@ data Part
     | PCapture String TypeInfo
     | PCaptureAll String TypeInfo
     | PQueryParam String TypeInfo
+    | PQueryParams String TypeInfo
     | PRequestBody TypeInfo
     | PHeader String TypeInfo
     deriving Show
@@ -162,6 +163,17 @@ instance (
         where
         prepend = fmap (prependPart part)
         part = PQueryParam (symbolVal (Proxy :: Proxy sym)) inf
+        inf = toTypeInfo (Proxy :: Proxy (Maybe a))
+
+-- Query params
+instance (
+    KnownSymbol sym,
+    Typeable a,
+    HasClientEndpoints api) => HasClientEndpoints (QueryParams sym (a :: *) :> api) where
+    endpoints Proxy = prepend $ endpoints (Proxy :: Proxy api)
+        where
+        prepend = fmap (prependPart part)
+        part = PQueryParams (symbolVal (Proxy :: Proxy sym)) inf
         inf = toTypeInfo (Proxy :: Proxy (Maybe a))
 
 -- Header

--- a/src/Servant/Client/Generic.hs
+++ b/src/Servant/Client/Generic.hs
@@ -123,18 +123,18 @@ instance (
         where
         prepend = fmap (prependPart part)
         part = PCapture (symbolVal (Proxy :: Proxy cap)) inf
-        inf = toTypeInfo (Proxy :: Proxy a)
+        inf = toTypeInfo @a
 
 -- CaptureAll
 instance (
     KnownSymbol cap,
-    Typeable [a],
+    Typeable a,
     HasClientEndpoints api) => HasClientEndpoints (CaptureAll cap a :> api) where
     endpoints Proxy = prepend $ endpoints (Proxy :: Proxy api) 
         where
         prepend = fmap (prependPart part)
         part = PCaptureAll (symbolVal (Proxy :: Proxy cap)) inf
-        inf = toTypeInfo (Proxy :: Proxy [a])
+        inf = toTypeInfo @a
 
 -- Request body
 instance (
@@ -144,7 +144,7 @@ instance (
         where
         prepend = fmap (prependPart part)
         part = PRequestBody inf
-        inf = toTypeInfo (Proxy :: Proxy a)
+        inf = toTypeInfo @a
 
 -- Query param
 instance (
@@ -155,7 +155,7 @@ instance (
         where
         prepend = fmap (prependPart part)
         part = PQueryParam (symbolVal (Proxy :: Proxy sym)) inf
-        inf = toTypeInfo (Proxy :: Proxy (Maybe a))
+        inf = toTypeInfo @a
 
 -- Query params
 instance (
@@ -166,7 +166,7 @@ instance (
         where
         prepend = fmap (prependPart part)
         part = PQueryParams (symbolVal (Proxy :: Proxy sym)) inf
-        inf = toTypeInfo (Proxy :: Proxy (Maybe a))
+        inf = toTypeInfo @a
 
 -- Header
 instance (
@@ -178,7 +178,7 @@ instance (
         name = symbolVal (Proxy :: Proxy sym)
         prepend = fmap (prependPart part)
         part = PHeader name inf
-        inf = toTypeInfo (Proxy :: Proxy a)
+        inf = toTypeInfo @a
 
 -- Verb
 instance HasClientEndpoints (Verb method status ctypes a) where
@@ -195,7 +195,7 @@ instance (
             eName = symbolVal (Proxy :: Proxy name),
             eParts = [],
             eVerb = toHttpMethod (Proxy :: Proxy method),
-            eResult = toTypeInfo (Proxy :: Proxy a)
+            eResult = toTypeInfo @a
         }
         
 type family ContainsJSON (a :: [*]) endpointName where
@@ -216,8 +216,8 @@ type family ContainsJSON (a :: [*]) endpointName where
 prependPart :: Part -> Endpoint -> Endpoint
 prependPart part e = e { eParts = part : eParts e }
 
-toTypeInfo :: Typeable a => Proxy a -> TypeInfo
-toTypeInfo = toTypeInfo' . typeRep
+toTypeInfo :: forall a. Typeable a => TypeInfo
+toTypeInfo = toTypeInfo' . typeRep $ Proxy @a
     where
     toTypeInfo' rep =
         let con = typeRepTyCon rep in

--- a/src/Servant/Client/Generic.hs
+++ b/src/Servant/Client/Generic.hs
@@ -205,8 +205,8 @@ type family ContainsJSON (a :: [*]) endpointName where
         ContainsJSON ax endpointName
     ContainsJSON '[] endpointName = TypeError 
         (     'Text "Cannot generate client for endpoint '" 
-        ':$$: 'Text endpointName 
-        ':$$: 'Text "', because it doesn't have JSON among its return encodings."
+        ':<>: 'Text endpointName 
+        ':<>: 'Text "', because it doesn't have JSON among its return encodings."
         )
         
 --


### PR DESCRIPTION
Originally I just wanted to add support for `QueryParams`, but then one thing led to another :-)

1. Support for `QueryParams`. Admittedly, we only use it in one place, and that place is not even PureScript-facing, but the whole thing didn't compile without it. I could have added dummy support, but it wasn't that hard, so why not?

2. Better error reporting. The last instance in the chain requires that the list of return encodings contains `JSON`, and if it doesn't, the error was "_Couldn't match 'False with 'True_". Thank you Haskell :-)
With this change, the error reads like "_Cannot generate client for endpoint 'foo', because it doesn't have JSON among its return encodings._" Will be a big help as we scale adoption.

3. I also changed the way types are reported: they are now passed verbatim, as they are specified in the API, without wrapping in lists or `Maybe`, and the frontend (i.e. codegen) can then decide whether to wrap them and how.

4. I also cleaned up the `Proxy` cruft a little.